### PR TITLE
Add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+Dockerfile
+README.md
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server ./cmd/server
+
+# Runtime stage
+FROM alpine:3.18
+WORKDIR /root/
+COPY --from=builder /app/server /usr/local/bin/server
+EXPOSE 8080
+CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,22 @@ Available endpoints:
 This codebase is intentionally minimal and only relies on
 [go-chi/chi](https://github.com/go-chi/chi) and
 [go-ethereum](https://github.com/ethereum/go-ethereum).
+
+## Docker
+
+You can build a container image and run the server with Docker Compose:
+
+```sh
+docker compose up --build
+```
+
+The compose file exposes port `8080` and relies on the following environment variables, which you can adjust in `docker-compose.yml`:
+
+- `RPC_HTTP_URL`
+- `RPC_WS_URL`
+- `PRIVATE_KEY`
+- `SUBGRAPH_URL`
+- `EPOCH_MANAGER_ADDR`
+- `VAULT_ADDR`
+- `CHAIN_ID`
+- `HTTP_PORT`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  server:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      RPC_HTTP_URL: http://localhost:8545
+      RPC_WS_URL: ws://localhost:8546
+      PRIVATE_KEY: change_me
+      SUBGRAPH_URL: http://localhost:8000/subgraphs/name/graph
+      EPOCH_MANAGER_ADDR: 0x0000000000000000000000000000000000000000
+      VAULT_ADDR: 0x0000000000000000000000000000000000000000
+      CHAIN_ID: 1
+      HTTP_PORT: 8080


### PR DESCRIPTION
## Summary
- introduce multi-stage Dockerfile to build and run the server
- provide docker-compose file with default environment variables
- document Docker usage in the README

## Testing
- `go test ./...`
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c5289cca88320b9b854e29a394f44