### PR TITLE
Ensure deterministic Merkle tree

### DIFF
--- a/pkg/merkletree/builder.go
+++ b/pkg/merkletree/builder.go
@@ -70,6 +70,17 @@ func Build(leaves []Leaf) (root [32]byte, proofs map[[20]byte][][]byte) {
 // is hashed as keccak256(account, amount). It returns the Merkle root and a map
 // of proofs keyed by the account address bytes.
 func BuildPairs(pairs []Pair) (root [32]byte, proofs map[[20]byte][][]byte) {
+	// Validate that the slice is sorted by address and amount to ensure
+	// deterministic Merkle root generation.
+	for i := 1; i < len(pairs); i++ {
+		prev := pairs[i-1]
+		curr := pairs[i]
+		addrCmp := bytes.Compare(prev.Account.Bytes(), curr.Account.Bytes())
+		if addrCmp > 0 || (addrCmp == 0 && prev.Amount.Cmp(curr.Amount) > 0) {
+			panic("unsorted recipients")
+		}
+	}
+
 	proofs = make(map[[20]byte][][]byte, len(pairs))
 	if len(pairs) == 0 {
 		return root, proofs

--- a/pkg/merkletree/merkle_test.go
+++ b/pkg/merkletree/merkle_test.go
@@ -1,0 +1,60 @@
+package merkletree
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func sortPairs(p []Pair) {
+	sort.Slice(p, func(i, j int) bool {
+		cmp := bytes.Compare(p[i].Account.Bytes(), p[j].Account.Bytes())
+		if cmp == 0 {
+			return p[i].Amount.Cmp(p[j].Amount) < 0
+		}
+		return cmp < 0
+	})
+}
+
+func TestBuildPairsGolden(t *testing.T) {
+	pairs := []Pair{
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000001"), Amount: big.NewInt(10)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000002"), Amount: big.NewInt(20)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000003"), Amount: big.NewInt(30)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000004"), Amount: big.NewInt(40)},
+	}
+	sortPairs(pairs)
+	root, _ := BuildPairs(pairs)
+	exp := "f9c15a18fa344d61d1ecae51a79db08cd99ec9f64d704dc02ea0648935c86696"
+	if hex.EncodeToString(root[:]) != exp {
+		t.Fatalf("unexpected root: %s", hex.EncodeToString(root[:]))
+	}
+}
+
+func FuzzDeterministicRoot(f *testing.F) {
+	base := []Pair{
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000001"), Amount: big.NewInt(10)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000002"), Amount: big.NewInt(20)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000003"), Amount: big.NewInt(30)},
+		{Account: common.HexToAddress("0x0000000000000000000000000000000000000004"), Amount: big.NewInt(40)},
+	}
+	sortPairs(base)
+	exp, _ := BuildPairs(base)
+	f.Add(int64(1))
+	f.Add(int64(2))
+	f.Fuzz(func(t *testing.T, seed int64) {
+		r := rand.New(rand.NewSource(seed))
+		pairs := append([]Pair{}, base...)
+		r.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+		sortPairs(pairs)
+		root, _ := BuildPairs(pairs)
+		if root != exp {
+			t.Fatalf("root changed: %x vs %x", root, exp)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- enforce sorted pairs when building Merkle tree to guarantee determinism
- sort recipients before building tree
- add tests for Merkle root stability

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68532175315c8320a96f1dcb5044dc44