### PR TITLE
Implement deterministic Merkle tree and subsidy aggregation

### DIFF
--- a/internal/service/subsidy/gather.go
+++ b/internal/service/subsidy/gather.go
@@ -1,0 +1,98 @@
+package subsidy
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/zap"
+
+	"go-server/internal/platform/graphql"
+)
+
+// gather collects total earned and previously claimed amounts for all recipients.
+func (s *Service) gather(ctx context.Context, epoch uint64) ([]Recipient, error) {
+	s.logger.Info("Gathering recipients for epoch", zap.Uint64("epoch", epoch))
+
+	first := 1000
+	skip := 0
+	type subResp struct {
+		AccountSubsidies []struct {
+			Recipient     string `json:"recipient"`
+			SecondsEarned string `json:"secondsEarned"`
+		} `json:"accountSubsidies"`
+	}
+
+	recipientsMap := make(map[common.Address]*big.Int)
+	query := `query GetSubsidies($first: Int!, $skip: Int!, $vault: String!) {
+        accountSubsidies(first: $first, skip: $skip, where: { vault: $vault }) {
+            recipient
+            secondsEarned
+        }
+    }`
+
+	client := graphql.NewClient(s.subgraphURL)
+	for {
+		vars := map[string]interface{}{
+			"first": first,
+			"skip":  skip,
+			"vault": s.vaultAddr.Hex(),
+		}
+		var resp subResp
+		if err := client.QueryWithVariables(ctx, query, vars, &resp); err != nil {
+			return nil, fmt.Errorf("query accountSubsidies: %w", err)
+		}
+		if len(resp.AccountSubsidies) == 0 {
+			break
+		}
+		for _, a := range resp.AccountSubsidies {
+			addr := common.HexToAddress(a.Recipient)
+			val, ok := new(big.Int).SetString(a.SecondsEarned, 10)
+			if !ok {
+				continue
+			}
+			if recipientsMap[addr] == nil {
+				recipientsMap[addr] = new(big.Int)
+			}
+			recipientsMap[addr].Add(recipientsMap[addr], val)
+		}
+		if len(resp.AccountSubsidies) < first {
+			break
+		}
+		skip += first
+	}
+
+	var recipients []Recipient
+	for addr, total := range recipientsMap {
+		claimed, err := s.claimedTotal(ctx, s.vaultAddr, addr)
+		if err != nil {
+			claimed = big.NewInt(0)
+			s.logger.Warn("failed to get claimedTotals", zap.String("addr", addr.Hex()), zap.Error(err))
+		}
+		if total.Cmp(claimed) > 0 {
+			recipients = append(recipients, Recipient{
+				Address:     addr,
+				TotalEarned: total,
+				PrevClaimed: claimed,
+			})
+		}
+	}
+
+	s.logger.Info("Finished gathering recipients", zap.Int("count", len(recipients)))
+	return recipients, nil
+}
+
+// claimedTotal calls the DebtSubsidizer contract to get previously claimed totals.
+func (s *Service) claimedTotal(ctx context.Context, vault, recipient common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := s.subsidizerContract.Call(&bind.CallOpts{Context: ctx}, &out, "claimedTotals", vault, recipient)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return big.NewInt(0), nil
+	}
+	return out[0].(*big.Int), nil
+}

--- a/pkg/merkletree/build.go
+++ b/pkg/merkletree/build.go
@@ -1,0 +1,31 @@
+package merkletree
+
+import (
+	"bytes"
+	"math/big"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Recipient represents an address with earned amount used for deterministic tree.
+type Recipient struct {
+	Address     common.Address
+	TotalEarned *big.Int
+}
+
+// BuildTree sorts recipients deterministically and builds the Merkle tree.
+func BuildTree(recipients []Recipient) (root [32]byte, proofs map[[20]byte][][]byte) {
+	sort.Slice(recipients, func(i, j int) bool {
+		if recipients[i].Address == recipients[j].Address {
+			return recipients[i].TotalEarned.Cmp(recipients[j].TotalEarned) < 0
+		}
+		return bytes.Compare(recipients[i].Address.Bytes(), recipients[j].Address.Bytes()) < 0
+	})
+
+	pairs := make([]Pair, len(recipients))
+	for i, r := range recipients {
+		pairs[i] = Pair{Account: r.Address, Amount: r.TotalEarned}
+	}
+	return BuildPairs(pairs)
+}

--- a/pkg/merkletree/builder.go
+++ b/pkg/merkletree/builder.go
@@ -75,6 +75,15 @@ func BuildPairs(pairs []Pair) (root [32]byte, proofs map[[20]byte][][]byte) {
 		return root, proofs
 	}
 
+	for i := 1; i < len(pairs); i++ {
+		prev := pairs[i-1]
+		curr := pairs[i]
+		if bytes.Compare(prev.Account.Bytes(), curr.Account.Bytes()) > 0 ||
+			(bytes.Equal(prev.Account.Bytes(), curr.Account.Bytes()) && prev.Amount.Cmp(curr.Amount) > 0) {
+			panic("unsorted recipients")
+		}
+	}
+
 	level := make([][32]byte, len(pairs))
 	for i, p := range pairs {
 		var amt [32]byte

--- a/pkg/merkletree/merkle_test.go
+++ b/pkg/merkletree/merkle_test.go
@@ -1,0 +1,43 @@
+package merkletree
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestBuildTreeGolden(t *testing.T) {
+	recipients := []Recipient{
+		{Address: common.HexToAddress("0x1111111111111111111111111111111111111111"), TotalEarned: big.NewInt(100)},
+		{Address: common.HexToAddress("0x2222222222222222222222222222222222222222"), TotalEarned: big.NewInt(50)},
+		{Address: common.HexToAddress("0x3333333333333333333333333333333333333333"), TotalEarned: big.NewInt(75)},
+	}
+	root, _ := BuildTree(recipients)
+	got := common.Bytes2Hex(root[:])
+	want := "1a4419cabd8afad85626382b2d212a6e6a1d49d5412ce08a76f8e8b18aab9907"
+	if got != want {
+		t.Fatalf("unexpected root %s", got)
+	}
+}
+
+func FuzzBuildTreeDeterministic(f *testing.F) {
+	base := []Recipient{
+		{Address: common.HexToAddress("0x1111111111111111111111111111111111111111"), TotalEarned: big.NewInt(100)},
+		{Address: common.HexToAddress("0x2222222222222222222222222222222222222222"), TotalEarned: big.NewInt(50)},
+		{Address: common.HexToAddress("0x3333333333333333333333333333333333333333"), TotalEarned: big.NewInt(75)},
+	}
+	root, _ := BuildTree(base)
+	want := root
+	f.Fuzz(func(t *testing.T, seed uint64) {
+		rs := make([]Recipient, len(base))
+		copy(rs, base)
+		rand.Seed(int64(seed))
+		rand.Shuffle(len(rs), func(i, j int) { rs[i], rs[j] = rs[j], rs[i] })
+		r2, _ := BuildTree(rs)
+		if r2 != want {
+			t.Fatalf("root mismatch")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- refactor subsidy gather logic to sum `accountSubsidies` and fetch `claimedTotals`
- add deterministic Merkle tree builder with sorting and validation
- update subsidy service to use new structures
- include tests for Merkle tree

## Testing
- `go test ./pkg/merkletree -run TestBuildTreeGolden -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68532175315c8320a96f1dcb5044dc44